### PR TITLE
feat(verify): add --dry-run flag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "Verification mode: warn or fail"
     required: false
     default: "fail"
+  dry-run:
+    description: "Validate bundle without writing summary.md"
+    required: false
+    default: "false"
   python-version:
     description: "Python version"
     required: false
@@ -17,7 +21,7 @@ runs:
         python-version: ${{ inputs.python-version }}
     - run: pip install .
       shell: bash
-    - run: proofpack verify --mode ${{ inputs.mode }} --json
+    - run: proofpack verify --mode ${{ inputs.mode }} --json${{ inputs.dry-run == 'true' && ' --dry-run' || '' }}
       shell: bash
     - uses: actions/upload-artifact@v4
       if: always()

--- a/src/proofpack/__main__.py
+++ b/src/proofpack/__main__.py
@@ -49,11 +49,13 @@ def stop() -> None:
 @click.option("--mode", type=click.Choice(["warn", "fail"]), default="fail",
               help="Verification mode: warn (exit 0) or fail (exit 1) on violations.")
 @click.option("--json", "json_output", is_flag=True, help="Output results as JSON.")
-def verify(mode: str, json_output: bool) -> None:
+@click.option("--dry-run", "dry_run", is_flag=True, default=False,
+              help="Validate bundle without writing summary.md.")
+def verify(mode: str, json_output: bool, dry_run: bool) -> None:
     """Verify a proofpack run."""
     from proofpack.commands.verify import cmd_verify
 
-    sys.exit(cmd_verify(mode=mode, json_output=json_output))
+    sys.exit(cmd_verify(mode=mode, json_output=json_output, dry_run=dry_run))
 
 
 @cli.command()

--- a/src/proofpack/commands/verify.py
+++ b/src/proofpack/commands/verify.py
@@ -25,12 +25,13 @@ def _read_receipt_integrity(pp_dir: Path) -> str:
         return "full"
 
 
-def cmd_verify(mode: str, json_output: bool) -> int:
+def cmd_verify(mode: str, json_output: bool, dry_run: bool = False) -> int:
     """Run the full verify pipeline and report results.
 
     Args:
         mode: "fail" to exit 1 on FAIL severity, "warn" to always exit 0.
         json_output: if True, emit JSON instead of Markdown summary.
+        dry_run: if True, skip writing summary.md to disk.
 
     Returns:
         0 on PASS/WARN, 1 on FAIL (when mode="fail").
@@ -99,8 +100,9 @@ def cmd_verify(mode: str, json_output: bool) -> int:
 
     # Generate and write summary
     summary_text = generate_summary(pp_dir, results, verdict)
-    summary_path = pp_dir / "summary.md"
-    summary_path.write_text(summary_text)
+    if not dry_run:
+        summary_path = pp_dir / "summary.md"
+        summary_path.write_text(summary_text)
 
     if json_output:
         output = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,3 +47,12 @@ def test_cli_status_help() -> None:
     )
     assert result.returncode == 0
     assert "session" in result.stdout.lower() or "status" in result.stdout.lower()
+
+
+def test_cli_verify_dry_run_in_help() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "proofpack", "verify", "--help"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    assert "--dry-run" in result.stdout

--- a/tests/test_cmd_verify.py
+++ b/tests/test_cmd_verify.py
@@ -126,3 +126,24 @@ def test_verify_json_output_standalone(tmp_path: Path, monkeypatch: object, caps
     assert data["verdict"] == "PASS"
     assert isinstance(data["checks"], list)
     assert len(data["checks"]) == 5
+
+
+def test_verify_dry_run_no_summary_file(tmp_path: Path, monkeypatch: object, capsys: object) -> None:
+    import pytest
+    mp = pytest.MonkeyPatch() if not isinstance(monkeypatch, pytest.MonkeyPatch) else monkeypatch
+    mp.chdir(tmp_path)
+    _make_full_proofpack(tmp_path)
+    result = cmd_verify(mode="fail", json_output=False, dry_run=True)
+    assert result == 0
+    assert not (tmp_path / ".proofpack" / "summary.md").exists()
+
+
+def test_verify_dry_run_still_prints(tmp_path: Path, monkeypatch: object, capsys: object) -> None:
+    import pytest
+    mp = pytest.MonkeyPatch() if not isinstance(monkeypatch, pytest.MonkeyPatch) else monkeypatch
+    mp.chdir(tmp_path)
+    _make_full_proofpack(tmp_path)
+    result = cmd_verify(mode="fail", json_output=False, dry_run=True)
+    assert result == 0
+    out = capsys.readouterr().out  # type: ignore[union-attr]
+    assert "PASS" in out or "proofpack" in out.lower()


### PR DESCRIPTION
## Summary

- Add `--dry-run` boolean flag to `proofpack verify` that runs all validation checks but skips writing `summary.md` to disk
- Stdout output (Markdown and JSON) preserved in dry-run mode
- Add `dry-run` input to `action.yml` for GitHub Actions integration

## Test plan

- [x] `test_cli_verify_dry_run_in_help` — `--dry-run` appears in verify help
- [x] `test_verify_dry_run_no_summary_file` — summary.md not written when dry_run=True
- [x] `test_verify_dry_run_still_prints` — stdout output preserved in dry-run mode
- [x] All 16 tests pass (`pytest tests/test_cli.py tests/test_cmd_verify.py`)